### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server for querying Uniswap pools/pairs by token address, delivering clean, structured results for easy integration and analysis.
 
+<a href="https://glama.ai/mcp/servers/@kukapay/uniswap-pools-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/uniswap-pools-mcp/badge" alt="uniswap-pools-mcp MCP server" />
+</a>
+
 ![GitHub License](https://img.shields.io/github/license/kukapay/uniswap-pools-mcp) 
 ![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg)
@@ -121,4 +125,3 @@ The server provides several tools to query Uniswap pool/pair data.
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
This PR adds a badge for the [uniswap-pools-mcp](https://glama.ai/mcp/servers/@kukapay/uniswap-pools-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/uniswap-pools-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/uniswap-pools-mcp/badge" alt="uniswap-pools-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.